### PR TITLE
fix: correct $id in schema.json to reference 1.0.2.1

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "$id": "https://raw.githubusercontent.com/kwf-ev/eldat-schema/1.0.2/schema.json",
+    "$id": "https://raw.githubusercontent.com/kwf-ev/eldat-schema/1.0.2.1/schema.json",
     "description": ".eldat data standard for communication between the partners in the wood supply chain.",
     "type": "object",
     "definitions": {


### PR DESCRIPTION
Related to #4.
On 1.0.2.1, schema_de.json's $id and title were already correct, so only schema.json's $id needed updating.
Note: schema_envelope.json's $id still references 1.0.1 — left alone as it's outside the scope of #4 and may be intentional.