### PR TITLE
fix: correct $id in schema_de.json to reference 1.0.4

### DIFF
--- a/schema_de.json
+++ b/schema_de.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://raw.githubusercontent.com/kwf-ev/eldat-schema/1.0.3/schema_de.json",
+	"$id": "https://raw.githubusercontent.com/kwf-ev/eldat-schema/1.0.4/schema_de.json",
 	"title": ".eldat schema 1.0.4",
 	"description": ".eldat data standard for communication between the partners in the wood supply chain.",
 	"type": "object",


### PR DESCRIPTION
Same $id URL fix as on 1.0.4. Related to #4.