### PR TITLE
fix: repair JSON syntax errors in schema_de.json

### DIFF
--- a/schema_de.json
+++ b/schema_de.json
@@ -3272,11 +3272,11 @@
                         "$ref": "#/definitions/haul_text",
                         "title": "Bemerkungen",
                         "description": "Freie Texteingaben zum Transportmittel"
+					}
 				},
 				"required": [
 					"haul_means_no",
-					"amount",
-					
+					"amount"	
                 ]
             },
             "properties": {},
@@ -3410,6 +3410,12 @@
                         "$ref": "#/definitions/other_file",
                         "title": "Dateianhang",
                         "description": ""
+					}
+				},
+				"required": [
+					"wood_id",
+					"product_data",
+					"coordinate"
                 ]
             },
             "properties": {},
@@ -5310,7 +5316,6 @@
                         "$ref": "#/definitions/allocated_wood",
                         "title": "Polterdaten",
                         "description": ""
-					
                     }
                 },
                 "required": [
@@ -5394,8 +5399,6 @@
                     "product_data",
                     "conversion_factor",
                     "coordinate"
-             
-                    
                 ]
             },
             "properties": {},


### PR DESCRIPTION
Fixes #10.
  
  - Closed missing `}` for inner `properties` object in `haul_means`
  - Removed trailing comma after "amount" in `haul_means.required`
  - Closed missing `}` for `other_file` and `properties` in `pile_data`
  - ...
  
Note: the schema is now parseable, but `#/definitions/eldat` still rejects all valid documents due to `additionalProperties: false` with empty `properties` — that's #11 and will be addressed in a separate PR on this branch.