### PR TITLE
Fix #11: restore valid eldat definition in schema_de.json

### DIFF
--- a/schema_de.json
+++ b/schema_de.json
@@ -55,7 +55,8 @@
                         "clearing": {
                             "$ref": "#/definitions/clearing"
                         }
-                    }
+                    },
+                    "required": ["clearing"]
                 },
                 {
                     "title": "Lieferschein",
@@ -64,7 +65,8 @@
                         "delivery_note": {
                             "$ref": "#/definitions/delivery_note"
                         }
-                    }
+                    },
+                    "required": ["delivery_note"]
                 },
                 {
                     "title": "Messprotokoll",
@@ -73,7 +75,8 @@
                         "measurement_journal": {
                             "$ref": "#/definitions/measurement_journal"
                         }
-                    }
+                    },
+                    "required": ["measurement_journal"]
                 },
                 {
                     "title": "Transportauftrag",
@@ -82,7 +85,8 @@
                         "transfer_order": {
                             "$ref": "#/definitions/transfer_order"
                         }
-                    }
+                    },
+                    "required": ["transfer_order"]
                 },
                 {
                     "title": "Holzbereitstellung",
@@ -91,11 +95,10 @@
                         "wood_allocation": {
                             "$ref": "#/definitions/wood_allocation"
                         }
-                    }
+                    },
+                    "required": ["wood_allocation"]
                 }
-            ],
-            "additionalProperties": false,
-            "properties": {}
+            ]
         },
         "clearing": {
             "type": "object",


### PR DESCRIPTION
Fixes #11
On 1.0.2, schema_de.json declared eldat with anyOf branches plus additionalProperties: false and an empty properties: {} at the same level.
Because additionalProperties is evaluated only against same-level properties (it ignores subschemas inside anyOf/oneOf/allOf), every document was rejected.
This drops the additionalProperties: false + properties: {} pair and adds a required array to each anyOf branch so each one matches only when its payload property is present. schema.json on this branch already used a working variant and is unchanged.