### PR TITLE
Fix #11: restore valid eldat definition in schema_de.json

### DIFF
--- a/schema_de.json
+++ b/schema_de.json
@@ -55,7 +55,8 @@
                         "clearing": {
                             "$ref": "#/definitions/clearing"
                         }
-                    }
+                    },
+                    "required": ["clearing"]
                 },
                 {
                     "title": "Lieferschein",
@@ -64,7 +65,8 @@
                         "delivery_note": {
                             "$ref": "#/definitions/delivery_note"
                         }
-                    }
+                    },
+                    "required": ["delivery_note"]
                 },
                 {
                     "title": "Messprotokoll",
@@ -73,7 +75,8 @@
                         "measurement_journal": {
                             "$ref": "#/definitions/measurement_journal"
                         }
-                    }
+                    },
+                    "required": ["measurement_journal"]
                 },
                 {
                     "title": "Transportauftrag",
@@ -82,7 +85,8 @@
                         "transfer_order": {
                             "$ref": "#/definitions/transfer_order"
                         }
-                    }
+                    },
+                    "required": ["transfer_order"]
                 },
                 {
                     "title": "Holzbereitstellung",
@@ -91,11 +95,10 @@
                         "wood_allocation": {
                             "$ref": "#/definitions/wood_allocation"
                         }
-                    }
+                    },
+                    "required": ["wood_allocation"]
                 }
-            ],
-            "additionalProperties": false,
-            "properties": {}
+            ]
         },
         "clearing": {
             "type": "object",


### PR DESCRIPTION
Fixes #11 on 1.0.2.1
Same bug as #11 on 1.0.2:
Drop additionalProperties:false combined with empty properties:{} which invalidated every document, since additionalProperties only consults same-level properties (not anyOf branches). Keep anyOf with each branch declaring its payload property inline and adding a required array so each branch only matches when its property is present.