### PR TITLE
Fix #11: add required per oneOf branch in eldat definition

### DIFF
--- a/schema_de.json
+++ b/schema_de.json
@@ -131,7 +131,8 @@
                         "wood_allocation": {
                             "$ref": "#/definitions/wood_allocation"
                         }
-                    }
+                    },
+                    "required": ["wood_allocation"]
                 },
                 {
                     "title": "Abrechnung",
@@ -140,7 +141,8 @@
                         "clearing": {
                             "$ref": "#/definitions/clearing"
                         }
-                    }
+                    },
+                    "required": ["clearing"]
                 },
                 {
                     "title": "Lieferschein",
@@ -149,7 +151,8 @@
                         "delivery_note": {
                             "$ref": "#/definitions/delivery_note"
                         }
-                    }
+                    },
+                    "required": ["delivery_note"]
                 },
                 {
                     "title": "Messprotokoll",
@@ -158,7 +161,8 @@
                         "measurement_journal": {
                             "$ref": "#/definitions/measurement_journal"
                         }
-                    }
+                    },
+                    "required": ["measurement_journal"]
                 },
                 {
                     "title": "Transportauftrag",
@@ -167,7 +171,8 @@
                         "transfer_order": {
                             "$ref": "#/definitions/transfer_order"
                         }
-                    }
+                    },
+                    "required": ["transfer_order"]
                 }
             ]
         },


### PR DESCRIPTION
Fixes #11 on 1.0.3
On 1.0.3, eldat was defined with a oneOf of five branches, each declaring a payload property under properties but with no required. Because branches don't constrain each other's properties, every branch matched any document vacuously, so oneOf always saw multiple matches and rejected everything (the same end-state as #11 on 1.0.2/1.0.2.1, via a different mechanism).
Adding required to each oneOf branch makes each branch match only when its payload property is present. This mirrors the shape 1.0.4 already uses.