### PR TITLE
Fix #22: fixed invalid ref:number in carbon_footprint_timber_harvest.co2_footprint_timber_harvest

### DIFF
--- a/schema_de.json
+++ b/schema_de.json
@@ -5604,7 +5604,7 @@
 				"co2_footprint_timber_harvest": {
 					"title": "CO2 Äquivalente der Emissionen durch die Holzernte",
 					"description": "Emissionen der Holzernte in CO2 Äquivalente in kg/fm",
-					"$ref": "number",
+					"type": "number",
 					"multipleOf": 0.01
 				}
 			}


### PR DESCRIPTION
Fixes #22 
Corrected malformed "$ref" -> "type"that prevents the schema from loading 