### PR TITLE
fix: rename EUDR_DDS_JSON properties to snake_case (#5)

### DIFF
--- a/schema_de.json
+++ b/schema_de.json
@@ -3169,10 +3169,10 @@
 						"title": "Bemerkungen",
 						"description": "Freie Texteingaben zum Transportmittel"
 					},
-					"EUDR_DDS_JSON": {
-						"$ref": "#/definitions/EUDR_DDS_JSON",
-						"title": "EUDR-Referenz",
-						"description": ""
+					"eudr_dds_json": {
+						"$ref": "#/definitions/eudr_dds_json",
+						"title": "EUDR-DDS-Referenz",
+						"description": "EUDR Due Diligence Statements (DDS)"
 					},
 					"carbon_footprint_timber_logistics": {
 						"$ref": "#/definitions/carbon_footprint_timber_logistics",
@@ -3183,7 +3183,7 @@
 				"required": [
 					"haul_means_no",
 					"amount",
-					"EUDR_DDS_JSON"
+					"eudr_dds_json"
 				]
 			},
 			"properties": {},
@@ -3301,17 +3301,17 @@
 						"title": "Dateianhang",
 						"description": ""
 					},
-					"EUDR_DDS_JSON": {
-						"$ref": "#/definitions/EUDR_DDS_JSON",
-						"title": "EUDR-Referenz",
-						"description": ""
+					"eudr_dds_json": {
+						"$ref": "#/definitions/eudr_dds_json",
+						"title": "EUDR-DDS-Referenz",
+						"description": "EUDR Due Diligence Statements (DDS)"
 					}
 				},
 				"required": [
 					"wood_id",
 					"product_data",
 					"coordinate",
-					"EUDR_DDS_JSON"
+					"eudr_dds_json"
 				]
 			},
 			"properties": {},
@@ -4414,10 +4414,10 @@
 						"title": "Polter",
 						"description": ""
 					},
-					"EUDR_DDS_JSON": {
-						"$ref": "#/definitions/EUDR_DDS_JSON",
-						"title": "EUDR-Referenz",
-						"description": ""
+					"eudr_dds_json": {
+						"$ref": "#/definitions/eudr_dds_json",
+						"title": "EUDR-DDS-Referenz",
+						"description": "EUDR Due Diligence Statements (DDS)"
 					},
 					"carbon_footprint_timber_harvest": {
 						"$ref": "#/definitions/carbon_footprint_timber_harvest",
@@ -4428,7 +4428,7 @@
 				"required": [
 					"wood_id",
 					"product_data",
-					"EUDR_DDS_JSON"
+					"eudr_dds_json"
 				]
 			},
 			"properties": {},
@@ -5553,41 +5553,42 @@
 				"route"
 			]
 		},
-		"EUDR_DDS_JSON": {
+		"eudr_dds_json": {
 			"type": "array",
 			"items": {
-				"title": "EUDR-Referenzen",
+				"title": "EUDR-DDS-Referenzen",
+				"description": "Referenzen zu EUDR Due Diligence Statements (DDS).",
 				"type": "object",
 				"properties": {
-					"EUDR_DDS_Referenznummer": {
+					"eudr_dds_reference_number": {
 						"$ref": "#/definitions/string40",
-						"title": "EUDR_DDS_Referenznummer",
+						"title": "EUDR-DDS-Referenznummer",
 						"description": "Referenznummer DDS"
 					},
-					"EUDR_DDS_Verifizierungsnummer_1": {
+					"eudr_dds_verification_number": {
 						"$ref": "#/definitions/string40",
-						"title": "EUDR_DDS_Verifizierungsnummer_1",
+						"title": "EUDR-DDS-Verifizierungsnummer",
 						"description": "verifiziert die Referenznummer DDS"
 					},
-					"EUDR_DDS_Georeferenz": {
+					"eudr_dds_georeference": {
 						"$ref": "https://geojson.org/schema/GeoJSON.json",
-						"title": "EUDR_DDS_Georeferenz",
+						"title": "EUDR-DDS-Georeferenz",
 						"description": "Geodaten zur DDS als GeoJSON: Punkte und/oder Polygonzüge"
 					},
-					"EUDR_DDS_URL": {
+					"eudr_dds_url": {
 						"$ref": "#/definitions/string250",
-						"title": "EUDR_DDS_URL",
+						"title": "EUDR-DDS-URL",
 						"description": "technisch nutzbare URL zur DDS, bspw. zur Bereitstellung von Zusatzinformationen"
 					},
-					"EUDR_DDS_Zusatzinfo": {
+					"eudr_dds_additional_info": {
 						"$ref": "#/definitions/string250",
-						"title": "EUDR_DDS_Zusatzinfo",
+						"title": "EUDR-DDS-Zusatzinfo",
 						"description": "zur freien Verfügung"
 					}
 				},
 				"required": [
-					"EUDR_DDS_Referenznummer",
-					"EUDR_DDS_Verifizierungsnummer_1"
+					"eudr_dds_reference_number",
+					"eudr_dds_verification_number"
 				]
 			}
 		},


### PR DESCRIPTION
Fixes #5 on the `1.0.4` branch.

Brings the EUDR DDS block in line with the project's snake_case property naming convention.
No semantic changes — only renames, plus minor title/description cleanup for consistency.

### Property renames

Outer definition / property:

| Before                     | After                  |
| --------------------- | ----------------- |
| `EUDR_DDS_JSON` | `eudr_dds_json`  |

Inner properties (drop `_1` suffix on the reference number, lowercase the rest):

| Before                                              | After                                            |
| -------------------------------------- | ----------------------------------- |
| `EUDR_DDS_Reference_number_1`  | `eudr_dds_reference_number`     |
| `EUDR_DDS_Verification_number`   | `eudr_dds_verification_number`  |
| `EUDR_DDS_Georeference`             | `eudr_dds_georeference`             |
| `EUDR_DDS_URL`                            | `eudr_dds_url`                              |
| `EUDR_DDS_Additional_info`          | `eudr_dds_additional_info`          |

All `$ref` targets and `required` array entries updated to match.

### Titles & descriptions

- Inner-property titles aligned to the `EUDR-DDS-*` prefix (`EUDR-DDS-Referenznummer`, `EUDR-DDS-Verifizierungsnummer`, `EUDR-DDS-Georeferenz`, `EUDR-DDS-URL`, `EUDR-DDS-Zusatzinfo`).
- Items title set to `EUDR-DDS-Referenzen`, items description set to `Referenzen zu EUDR Due Diligence Statements (DDS).`
- All three property usages now have title `EUDR-DDS-Referenz` and description `EUDR Due Diligence Statements (DDS)` for consistency.

### Scope

This PR only addresses the `1.0.4` branch. An equivalent PR for `1.0.2.1` will follow with identical decisions.