### PR TITLE
fix: rename EUDR_DDS_JSON properties to snake_case (#5)

### DIFF
--- a/schema_de.json
+++ b/schema_de.json
@@ -3276,10 +3276,10 @@
                         "title": "Bemerkungen",
                         "description": "Freie Texteingaben zum Transportmittel"
                     },
-                    "EUDR_DDS_JSON": {
-                        "$ref": "#/definitions/EUDR_DDS_JSON",
-                        "title": "EUDR-Referenz",
-                        "description": ""
+                    "eudr_dds_json": {
+                        "$ref": "#/definitions/eudr_dds_json",
+                        "title": "EUDR-DDS-Referenz",
+                        "description": "EUDR Due Diligence Statements (DDS)"
                     },
                     "carbon_footprint_timber_logistics": {
                         "$ref": "#/definitions/carbon_footprint_timber_logistics",
@@ -3290,7 +3290,7 @@
                 "required": [
                     "haul_means_no",
                     "amount",
-                    "EUDR_DDS_JSON"
+                    "eudr_dds_json"
                 ]
             },
             "properties": {},
@@ -3425,17 +3425,17 @@
                         "title": "Dateianhang",
                         "description": ""
                     },
-                    "EUDR_DDS_JSON": {
-                        "$ref": "#/definitions/EUDR_DDS_JSON",
-                        "title": "EUDR-Referenz",
-                        "description": ""
+                    "eudr_dds_json": {
+                        "$ref": "#/definitions/eudr_dds_json",
+                        "title": "EUDR-DDS-Referenz",
+                        "description": "EUDR Due Diligence Statements (DDS)"
                     }
                 },
                 "required": [
                     "wood_id",
                     "product_data",
                     "coordinate",
-                    "EUDR_DDS_JSON"
+                    "eudr_dds_json"
                 ]
             },
             "properties": {},
@@ -5337,10 +5337,10 @@
                         "title": "Polterdaten",
                         "description": ""
                     },
-                    "EUDR_DDS_JSON": {
-                        "$ref": "#/definitions/EUDR_DDS_JSON",
-                        "title": "EUDR-Referenz",
-                        "description": ""
+                    "eudr_dds_json": {
+                        "$ref": "#/definitions/eudr_dds_json",
+                        "title": "EUDR-DDS-Referenz",
+                        "description": "EUDR Due Diligence Statements (DDS)"
                     },
                     "carbon_footprint_timber_harvest": {
                         "$ref": "#/definitions/carbon_footprint_timber_harvest",
@@ -5353,7 +5353,7 @@
                     "measurement_method",
                     "felling_date",
                     "allocated_wood",
-                    "EUDR_DDS_JSON"
+                    "eudr_dds_json"
                 ]
             },
             "properties": {},
@@ -5419,10 +5419,10 @@
                         "title": "Koordinaten",
                         "description": ""
                     },
-                    "EUDR_DDS_JSON": {
-                        "$ref": "#/definitions/EUDR_DDS_JSON",
-                        "title": "EUDR-Referenz",
-                        "description": ""
+                    "eudr_dds_json": {
+                        "$ref": "#/definitions/eudr_dds_json",
+                        "title": "EUDR-DDS-Referenz",
+                        "description": "EUDR Due Diligence Statements (DDS)"
                     },
                     "carbon_footprint_timber_harvest": {
                         "$ref": "#/definitions/carbon_footprint_timber_harvest",
@@ -5440,7 +5440,7 @@
                     "product_data",
                     "conversion_factor",
                     "coordinate",
-                    "EUDR_DDS_JSON"
+                    "eudr_dds_json"
                 ]
             },
             "properties": {},
@@ -5465,41 +5465,42 @@
             "type": "string",
             "maxLength": 35
         },
-        "EUDR_DDS_JSON": {
+        "eudr_dds_json": {
             "type": "array",
             "items": {
-                "title": "EUDR-Referenzen",
+                "title": "EUDR-DDS-Referenzen",
+                "description": "Referenzen zu EUDR Due Diligence Statements (DDS).",
                 "type": "object",
                 "properties": {
-                    "EUDR_DDS_Referenznummer": {
+                    "eudr_dds_reference_number": {
                         "$ref": "#/definitions/string50",
-                        "title": "EUDR_DDS_Referenznummer",
+                        "title": "EUDR-DDS-Referenznummer",
                         "description": "Referenznummer DDS"
                     },
-                    "EUDR_DDS_Verifizierungsnummer_1": {
+                    "eudr_dds_verification_number": {
                         "$ref": "#/definitions/string35",
-                        "title": "EUDR_DDS_Verifizierungsnummer_1",
+                        "title": "EUDR-DDS-Verifizierungsnummer",
                         "description": "verifiziert die Referenznummer DDS"
                     },
-                    "EUDR_DDS_Georeferenz": {
+                    "eudr_dds_georeference": {
                         "$ref": "https://geojson.org/schema/GeoJSON.json",
-                        "title": "EUDR_DDS_Georeferenz",
+                        "title": "EUDR-DDS-Georeferenz",
                         "description": "Geodaten zur DDS als GeoJSON: Punkte und/oder Polygonzüge"
                     },
-                    "EUDR_DDS_URL": {
+                    "eudr_dds_url": {
                         "$ref": "#/definitions/string250",
-                        "title": "EUDR_DDS_URL",
+                        "title": "EUDR-DDS-URL",
                         "description": "technisch nutzbare URL zur DDS, bspw. zur Bereitstellung von Zusatzinformationen"
                     },
-                    "EUDR_DDS_Zusatzinfo": {
+                    "eudr_dds_additional_info": {
                         "$ref": "#/definitions/string250",
-                        "title": "EUDR_DDS_Zusatzinfo",
+                        "title": "EUDR-DDS-Zusatzinfo",
                         "description": "zur freien Verfügung"
                     }
                 },
                 "required": [
-                    "EUDR_DDS_Referenznummer",
-                    "EUDR_DDS_Verifizierungsnummer_1"
+                    "eudr_dds_reference_number",
+                    "eudr_dds_verification_number"
                 ]
             }
         },


### PR DESCRIPTION
Fixes #5 on the `1.0.2.1` branch.

Brings the EUDR DDS block in line with the project's snake_case property naming convention.
Mirrors the equivalent fix already applied on `1.0.4`.
No semantic changes — only renames, plus minor title/description cleanup for consistency.

### Property renames

Outer definition / property:

| Before                     | After                  |
| --------------------- | ----------------- |
| `EUDR_DDS_JSON` | `eudr_dds_json`  |

Inner properties (drop the `_1` suffix on the verification number, translate German names to English snake_case):

| Before                                                  | After                                           |
| ----------------------------------------- | ---------------------------------- |
| `EUDR_DDS_Referenznummer`            | `eudr_dds_reference_number`    |
| `EUDR_DDS_Verifizierungsnummer_1` | `eudr_dds_verification_number` |
| `EUDR_DDS_Georeferenz`                    | `eudr_dds_georeference`            |
| `EUDR_DDS_URL`                                 | `eudr_dds_url`                             |
| `EUDR_DDS_Zusatzinfo`                       | `eudr_dds_additional_info`         |

All `$ref` targets and `required` array entries updated to match.

### Titles & descriptions

- Inner-property titles aligned to the `EUDR-DDS-*` prefix (`EUDR-DDS-Referenznummer`, `EUDR-DDS-Verifizierungsnummer`,
  `EUDR-DDS-Georeferenz`, `EUDR-DDS-URL`, `EUDR-DDS-Zusatzinfo`).
- Items title set to `EUDR-DDS-Referenzen`, items description added: `Referenzen zu EUDR Due Diligence Statements (DDS).`
- All four property usages now have title `EUDR-DDS-Referenz` and description `EUDR Due Diligence Statements (DDS)` for consistency.

### Scope

This PR only addresses the `1.0.2.1` branch. The equivalent change on `1.0.4` is in a separate PR.