### PR TITLE
fix: replace invalid "quality" required entry with "wood_id" in product_pile (#2)

### DIFF
--- a/schema_de.json
+++ b/schema_de.json
@@ -3381,7 +3381,7 @@
                     }
                 },
                 "required": [
-                    "quality",
+                    "wood_id",
                     "grade",
                     "use",
                     "amount",


### PR DESCRIPTION
Fixes #2 on the 1.0.3-updated branch.

The `product_pile` definition listed `quality` in its `required` array, but `quality` is not a property of `product_pile` — it lives inside
`wood_definition`, several levels deeper. As a result the schema could never validate any document against `product_pile`.

Replacing `quality` with `wood_id` as this property actually identifies the wood entry at this level.